### PR TITLE
Fix usage text

### DIFF
--- a/src/usage.hpp
+++ b/src/usage.hpp
@@ -4,7 +4,7 @@
 
 static std::string compact_usage =
 
-"usage: voraig [ <option> ... ] [ <model> <counter_example> <witness_circuit> ]\n"
+"usage: voiraig [ <option> ... ] [ <model> <counter_example> <witness_circuit> ]\n"
 "\n"
 "where '<option>' is one of the following\n"
 "\n"


### PR DESCRIPTION
## Summary
- update usage string to use the correct executable name

## Testing
- `make`
- `./bin/voiraig -h`
- `./bin/voiraig`

------
https://chatgpt.com/codex/tasks/task_e_684924a5db7c8320b83bcb76c590fe57